### PR TITLE
Fixed duplicate save call in VisitorService causing a ConstraintViolation

### DIFF
--- a/CTT-Github/src/main/java/de/hs_mannheim/informatik/ct/persistence/services/VisitorService.java
+++ b/CTT-Github/src/main/java/de/hs_mannheim/informatik/ct/persistence/services/VisitorService.java
@@ -3,6 +3,7 @@ package de.hs_mannheim.informatik.ct.persistence.services;
 
 import de.hs_mannheim.informatik.ct.model.Visitor;
 import de.hs_mannheim.informatik.ct.persistence.repositories.VisitorRepository;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +22,6 @@ public class VisitorService {
     @Transactional
     public Visitor findOrCreateVisitor(String email) {
         return findVisitorByEmail(email)
-                .orElse(
-                        visitorRepo.save(new Visitor(email)));
+                .orElseGet(() -> visitorRepo.save(new Visitor(email)));
     }
 }

--- a/CTT-Github/src/test/java/de/hs_mannheim/informatik/ct/persistence/services/VisitorServiceTest.java
+++ b/CTT-Github/src/test/java/de/hs_mannheim/informatik/ct/persistence/services/VisitorServiceTest.java
@@ -1,0 +1,74 @@
+package de.hs_mannheim.informatik.ct.persistence.services;
+
+import de.hs_mannheim.informatik.ct.model.Visitor;
+import de.hs_mannheim.informatik.ct.persistence.repositories.VisitorRepository;
+import lombok.val;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class VisitorServiceTest {
+    @TestConfiguration
+    static class VisitorServiceTestConfig {
+        @Bean
+        public VisitorService visitorService() {
+            return new VisitorService();
+        }
+    }
+
+    @MockBean
+    private VisitorRepository visitorRepository;
+
+    @Autowired
+    private VisitorService visitorService;
+
+    private AutoCloseable mocks;
+
+    @BeforeEach
+    public void openMocks() {
+        mocks = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    public void releaseMocks() throws Exception {
+        mocks.close();
+    }
+
+    /**
+     * There was a bug that caused the findOrCreateVisitor method to save the visitor even if it was found. This causes
+     * a constraint violation, Therefore ensure that save is ONLY called if the visitor wasn't found.
+     */
+    @Test
+    void finOrCreateNoDuplicateSave() {
+        val email = "1234@stud.hs-mannheim.de";
+        val visitor = new Visitor();
+        // The visitor doesn't exist yet
+
+        doReturn(Optional.empty()).when(visitorRepository).findByEmail(email);
+        visitorService.findOrCreateVisitor(email);
+
+        // The visitor exists now
+        doReturn(Optional.of(visitor)).when(visitorRepository).findByEmail(email);
+        Assertions.assertTrue(visitorService.findVisitorByEmail(email).isPresent());
+        // This should return the visitor without creating a new one
+        visitorService.findOrCreateVisitor(email);
+
+        // Finally ensure that save was called exactly once
+        verify(
+                visitorRepository,
+                Mockito.times(1))
+                .save(any(Visitor.class));
+    }
+}


### PR DESCRIPTION
In `findOrCreateVisitor` wurde der Visitor immer gesaved, auch wenn er bereits existiert. Vor der Änderung des Visitor Primary Key war das unproblematisch (#30), jetzt führt es aber dazu das beim zweiten Einchecken eines Nutzers eine ConstraintViolationExecption geworfen wird.

Nachdem die PR approved ist merge ich den Branch auch in dev.