### PR TITLE
Added production toggle

### DIFF
--- a/CTT-Github/docker-compose.yml
+++ b/CTT-Github/docker-compose.yml
@@ -12,6 +12,12 @@ services:
       - SPRING_JPA_HIBERNATE_DDL_AUTO=update
       - SPRING_H2_CONSOLE_ENABLED=false
       - SERVER_TOMCAT_ACCESSLOG_ENABLED=false
+      - SERVER_ENV=production
+      - SERVER_ADDRESS=0.0.0.0
+      # A list of users in the format Username1,EncryptedPassword1,Role1,Role2;Username2,EncryptedPassword2,Role2;
+      # Override with your own credentials in a .env file next to docker-compose.yml
+      # Passwords are encrypted using Bcrypt in Java Spring. (Use org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder.encode("passwordToEncode") )
+      - USER_CREDENTIALS=user,$2a$10$WUJevKFYLHfIheVZ3yv7J.7uIHeoPV8fAb9wFqdW50kFD8O4EWJ4u,USER;prof,$2a$10$WUJevKFYLHfIheVZ3yv7J.7uIHeoPV8fAb9wFqdW50kFD8O4EWJ4u,PROF;admin,$2a$10$nW.GjVHey9UA47Xv8V8yHe5WQ67rNLsI3bjdi8gIM/28MufxGc53a,PROF,ADMIN;
     restart: always
   db:
     image: postgres:13-alpine

--- a/CTT-Github/src/main/java/de/hs_mannheim/informatik/ct/persistence/DbInit.java
+++ b/CTT-Github/src/main/java/de/hs_mannheim/informatik/ct/persistence/DbInit.java
@@ -21,6 +21,7 @@ package de.hs_mannheim.informatik.ct.persistence;
 import de.hs_mannheim.informatik.ct.model.Room;
 import de.hs_mannheim.informatik.ct.persistence.repositories.RoomRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Service;
 
@@ -28,15 +29,19 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class DbInit implements CommandLineRunner {
+    @Value("${server_env:production}")
+    private String serverEnvironment;
+
     @Autowired
     private RoomRepository roomsRepo;
 
-    // TODO: nur testweise für den Moment, später wieder entfernen
     @Override
     public void run(String... args) {
-        roomsRepo.save(new Room("A007a","A", 3));
-        roomsRepo.save(new Room("test","test", 12));
-        roomsRepo.save(new Room("A210","A", 19));
+        if(serverEnvironment.equals("dev")) {
+            roomsRepo.save(new Room("A007a", "A", 3));
+            roomsRepo.save(new Room("test", "test", 12));
+            roomsRepo.save(new Room("A210", "A", 19));
+        }
     }
 
 }

--- a/CTT-Github/src/main/resources/application.properties
+++ b/CTT-Github/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Set to production on live systems
+server_env=dev
+
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.url=jdbc:h2:./h2db/database;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;AUTO_RECONNECT=TRUE
 spring.datasource.username=minda
@@ -11,13 +14,14 @@ spring.h2.console.enabled=true
 
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
-#spring.jpa.hibernate.ddl-auto=create
 
 spring.thymeleaf.cache=false
 spring.thymeleaf.enabled=true
 spring.thymeleaf.prefix=classpath:/templates/
 spring.thymeleaf.suffix=.html
 
+# Only allow connections from the localhost in dev mode, if you override this make sure to set server_env to production!
+server.address=localhost
 server.port=8080
 hostname=localhost
 


### PR DESCRIPTION
Mit `SERVER_ENV={production|dev}` kann man jetzt zwischen den beiden Modi wechseln.

Aktuell macht das folgende Unterschiede:
## dev
* Standard Klartext Passwörter werden verwendet (admin:admin)
* Testräume werden angelegt
* Nicht direkt mit dev konfiguriert, aber standardmäßig lässt der Server nur noch Verbindungen von localhost zu
## production
* Passwörter werden aus `USER_CREDENTIALS` geladen (A list of users in the format Username1,EncryptedPassword1,Role1,Role2;Username2,EncryptedPassword2,Role2;)

In `docker-compose.yml` sind defaults für einen Production Server eingetragen