### PR TITLE
Fixed Check-In adding null to external emails

### DIFF
--- a/CTT-Github/src/main/resources/static/checkInForm.js
+++ b/CTT-Github/src/main/resources/static/checkInForm.js
@@ -101,7 +101,12 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     function getFullEmail() {
-        return emailText.value + emailPostfix;
+        // Check if the postfix is null
+        if(!!emailPostfix) {
+            return emailText.value + emailPostfix;
+        } else {
+            return emailText.value;
+        }
     }
 
     function showJSEnabled() {


### PR DESCRIPTION
Beim Check-In wurden externe E-Mail Adressen als `email@provider.comnull` an das Backend geschickt da eine Überprüfung fehlte.