### PR TITLE
Changed tracing to tracking in documentation

### DIFF
--- a/CTT_ist_toll_weil.txt
+++ b/CTT_ist_toll_weil.txt
@@ -1,4 +1,4 @@
-Argumente für das Corona Tracing Tool (CTT)
+Argumente für das Corona Tracking Tool (CTT)
 
 - CTT ist so einfach und sicher zu benutzen das Infektionschhutz praktischer wird.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     </a>
 </p>
 
-The goal of this project is to develop an open source contact tracing solution for public institutions, especially universities and colleges. Students can check into a room at the beginning of their lecture, using a QR code and their student mail. Non faculty members may be required to provide additional information to allow effective tracing in the case of an infection. The project was created around the principals of transparency and privacy. All gathered data is deleted automatically after the required period. Further information can be be accessed in German: [Datenschutz](https://ctt.hs-mannheim.de/datenschutz)
+The goal of this project is to develop an open source contact tracking solution for public institutions, especially universities and colleges. Students can check into a room at the beginning of their lecture, using a QR code and their student mail. Non faculty members may be required to provide additional information to allow effective tracking in the case of an infection. The project was created around the principals of transparency and privacy. All gathered data is deleted automatically after the required period. Further information can be be accessed in German: [Datenschutz](https://ctt.hs-mannheim.de/datenschutz)
 
 ## Setup
 


### PR DESCRIPTION
Closes #116.

Corona tracking tool was voted as the favored name in November, so I changed the readme to this wording. Tracing is now only referenced in source code, but in reference to 'Kontaktverfolgung' where it makes sense imo.