### PR TITLE
changed button link to a link relative to the root

### DIFF
--- a/src/main/resources/templates/rooms/full.html
+++ b/src/main/resources/templates/rooms/full.html
@@ -17,7 +17,7 @@
     </div>
     <p>Bereits in diesem Raum angemeldet?</p>
     <p>
-        <a class="button" th:href="@{${roomData.roomId}+ '/checkOut'}">Abmelden</a>
+        <a class="button" th:href="@{'/r/'+${roomData.roomId}+'/checkOut'}">Abmelden</a>
     </p>
 
 </div>


### PR DESCRIPTION
Hi, der Fehler war folgender: 
Wenn man in einen vollen Raum über die manuelle Raumeingabe auf der Startseite einchecken wollte, dann findet im RoomController (@GetMapping("/{roomId}")) intern einen weiterleitung ("forward:foomFull/") zum  @RequestMapping("/roomFull/{roomId}") statt. Da die Weiterleitung durch forward und nicht durch redirect passiert, ändert sich die URL auch nicht. Wenn man dann auf abmelden klickt hat man immer noch die ursprüngliche url (/r/noId?roomId=A007a) an die nur ein /checkOut angehägt wird.
Wenn der client sich aber direkt über den Link "r/roomFull/A007a" abmelden möchte wird ebenso ein /checkout angehängt und dann der 404 Fehler geworfen, da die url durch das zusätzliche roomFull unbekannt ist.
Ich habe jetzt lediglich den Button-Link im full.html template geändert, so dass er relativ zur root ist.